### PR TITLE
Add System extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ use tokio::fs;
 use tokio::io::Error;
 
 /// We need to declare both the parent and the child type inside the extractors
-fn plus_one(mut counter: Update<State, i32>, tgt: Target<State, i32>, Path(name): Path<String>) -> Effect<Update<i32>, Error>  {
+fn plus_one(mut counter: Update<State, i32>, tgt: Target<State, i32>, Args(name): Args<String>) -> Effect<Update<i32>, Error>  {
     if *counter < *tgt {
         // Modify the counter value if we are below the target
         *counter += 1;
@@ -192,7 +192,7 @@ On the above example, the job definition is practically identical to the one in 
 As programmers, we want to be able to build code by composing simpler behaviors into more complex ones. We might want to guide the planner towards a specific solution, using the primitives we already have. For instance, let's say we want to help the planner get to a solution faster as adding tasks one by one takes too much time. We want to define a `plus_two` task, that increases the counter by 2. We could create another primitive task to update the counter by two, but as programmers, we would like to reuse the code we have already defined. We can do that using methods.
 
 ```rust
-fn plus_two(counter: Update<State, i32>, tgt: Target<State, i32>, Path(name): Path<String>) -> Vec<Task<i32>> {
+fn plus_two(counter: Update<State, i32>, tgt: Target<State, i32>, Args(name): Args<String>) -> Vec<Task<i32>> {
     if *tgt - *counter < 2 {
         // Returning an empty result tells the planner
         // the task is not applicable to reach the target
@@ -202,8 +202,8 @@ fn plus_two(counter: Update<State, i32>, tgt: Target<State, i32>, Path(name): Pa
     // A compound job returns a list of tasks that need to be executed
     // to achieve a certain goal
     vec![
-        plus_one.into_task(Context::new().target(*tgt).arg("name", &name)),
-        plus_one.into_task(Context::new().target(*tgt).arg("name", &name)),
+        plus_one.with_target(*tgt).with_arg("name", name.clone()),
+        plus_one.with_target(*tgt).with_arg("name", name.clone()),
     ]
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
     #[error("cannot extract view: ${0}")]
     ViewExtractFailed(#[from] super::extract::ViewExtractError),
 
+    #[error("cannot extract system")]
+    SystemExtractFailed(#[from] super::extract::SystemExtractError),
+
     #[error("cannot calculate view result: ${0}")]
     ViewResultFailed(#[from] super::extract::ViewResultError),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,8 +11,8 @@ pub enum Error {
     #[error("cannot write system state: ${0}")]
     StateWriteFailed(#[from] super::system::SystemWriteError),
 
-    #[error("cannot extract path: ${0}")]
-    PathExtractFailed(#[from] super::extract::PathDeserializationError),
+    #[error("cannot extract args: ${0}")]
+    ArgsExtractFailed(#[from] super::extract::ArgsDeserializationError),
 
     #[error("cannot extract target: ${0}")]
     TargetExtractFailed(#[from] super::extract::TargetExtractError),

--- a/src/extract/args/error.rs
+++ b/src/extract/args/error.rs
@@ -29,11 +29,11 @@ use std::fmt;
 // this wrapper type is used as the deserializer error to hide the `serde::de::Error` impl which
 // would otherwise be public if we used `ErrorKind` as the error directly
 #[derive(Debug)]
-pub struct PathDeserializationError {
+pub struct ArgsDeserializationError {
     pub(super) kind: ErrorKind,
 }
 
-impl PathDeserializationError {
+impl ArgsDeserializationError {
     pub(super) fn new(kind: ErrorKind) -> Self {
         Self { kind }
     }
@@ -60,15 +60,15 @@ impl<G> WrongNumberOfParameters<G> {
 }
 
 impl WrongNumberOfParameters<usize> {
-    pub(super) fn expected(self, expected: usize) -> PathDeserializationError {
-        PathDeserializationError::new(ErrorKind::WrongNumberOfParameters {
+    pub(super) fn expected(self, expected: usize) -> ArgsDeserializationError {
+        ArgsDeserializationError::new(ErrorKind::WrongNumberOfParameters {
             got: self.got,
             expected,
         })
     }
 }
 
-impl serde::de::Error for PathDeserializationError {
+impl serde::de::Error for ArgsDeserializationError {
     #[inline]
     fn custom<T>(msg: T) -> Self
     where
@@ -80,13 +80,13 @@ impl serde::de::Error for PathDeserializationError {
     }
 }
 
-impl fmt::Display for PathDeserializationError {
+impl fmt::Display for ArgsDeserializationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.kind.fmt(f)
     }
 }
 
-impl std::error::Error for PathDeserializationError {}
+impl std::error::Error for ArgsDeserializationError {}
 
 /// The kinds of errors that can happen we deserializing into a [`Path`].
 #[derive(Debug, PartialEq, Eq)]

--- a/src/extract/args/mod.rs
+++ b/src/extract/args/mod.rs
@@ -8,27 +8,27 @@ use crate::task::Context;
 mod de;
 mod error;
 
-pub use error::PathDeserializationError;
+pub use error::ArgsDeserializationError;
 
-impl IntoError for PathDeserializationError {
+impl IntoError for ArgsDeserializationError {
     fn into_error(self) -> Error {
-        Error::PathExtractFailed(self)
+        Error::ArgsExtractFailed(self)
     }
 }
 
 #[derive(Debug)]
-pub struct Path<T>(pub T);
+pub struct Args<T>(pub T);
 
-impl<T: DeserializeOwned + Send> FromSystem for Path<T> {
-    type Error = PathDeserializationError;
+impl<T: DeserializeOwned + Send> FromSystem for Args<T> {
+    type Error = ArgsDeserializationError;
 
     fn from_system(_: &System, context: &Context) -> Result<Self, Self::Error> {
         let args = &context.args;
-        T::deserialize(de::PathDeserializer::new(args)).map(Path)
+        T::deserialize(de::PathDeserializer::new(args)).map(Args)
     }
 }
 
-impl<S> Deref for Path<S> {
+impl<S> Deref for Args<S> {
     type Target = S;
 
     fn deref(&self) -> &Self::Target {
@@ -59,8 +59,8 @@ mod tests {
 
         let system = System::from(state);
 
-        let Path(name): Path<String> =
-            Path::from_system(&system, &Context::new().with_arg("name", "one")).unwrap();
+        let Args(name): Args<String> =
+            Args::from_system(&system, &Context::new().with_arg("name", "one")).unwrap();
 
         assert_eq!(name, "one");
     }
@@ -75,7 +75,7 @@ mod tests {
 
         let system = System::from(state);
 
-        let Path((first, second)): Path<(String, String)> = Path::from_system(
+        let Args((first, second)): Args<(String, String)> = Args::from_system(
             &system,
             &Context::new()
                 .with_arg("first", "one")
@@ -97,7 +97,7 @@ mod tests {
 
         let system = System::from(state);
 
-        let Path(map): Path<HashMap<String, String>> = Path::from_system(
+        let Args(map): Args<HashMap<String, String>> = Args::from_system(
             &system,
             &Context::new()
                 .with_arg("first", "one")

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -1,9 +1,9 @@
-mod path;
+mod args;
 mod system;
 mod target;
 mod view;
 
-pub use path::*;
+pub use args::*;
 pub use system::*;
 pub use target::*;
 pub use view::*;

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -1,7 +1,9 @@
 mod path;
+mod system;
 mod target;
 mod view;
 
 pub use path::*;
+pub use system::*;
 pub use target::*;
 pub use view::*;

--- a/src/extract/system.rs
+++ b/src/extract/system.rs
@@ -1,0 +1,47 @@
+use serde::de::DeserializeOwned;
+use std::fmt::{self, Display};
+
+use crate::error::{Error, IntoError};
+
+use crate::system::{FromSystem, System as SystemState};
+use crate::task::Context;
+
+#[derive(Debug)]
+pub struct SystemExtractError(serde_json::error::Error);
+
+impl std::error::Error for SystemExtractError {}
+
+impl Display for SystemExtractError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl IntoError for SystemExtractError {
+    fn into_error(self) -> Error {
+        Error::SystemExtractFailed(self)
+    }
+}
+
+/// Extracts the root of the system state
+#[derive(Debug, Clone)]
+pub struct System<S>(pub S);
+
+impl<S: DeserializeOwned> FromSystem for System<S> {
+    type Error = SystemExtractError;
+
+    fn from_system(system: &SystemState, _: &Context) -> Result<Self, Self::Error> {
+        // This will fail if the value cannot be deserialized into the target type
+        let state =
+            serde_json::from_value::<S>(system.root().clone()).map_err(SystemExtractError)?;
+
+        Ok(Self(state))
+    }
+
+    // The System extractor allows a handler to read from anywhere
+    // in the state, breaking the scope of the handler and preventing
+    // parallelization
+    fn is_scoped() -> bool {
+        false
+    }
+}

--- a/src/system/from_system.rs
+++ b/src/system/from_system.rs
@@ -7,4 +7,10 @@ pub trait FromSystem: Sized {
     type Error: IntoError + 'static;
 
     fn from_system(state: &System, context: &Context) -> Result<Self, Self::Error>;
+
+    /// The extractor is scoped if it only requires access to some
+    /// part of the system state rather than to the global state
+    fn is_scoped() -> bool {
+        true
+    }
 }

--- a/src/task/context.rs
+++ b/src/task/context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jsonptr::PointerBuf;
 use serde::Serialize;
 use serde_json::Value;
@@ -7,7 +5,7 @@ use serde_json::Value;
 use super::result::Result;
 use crate::path::{Path, PathArgs};
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct Context {
     pub(crate) target: Value,
     pub(crate) path: Path,
@@ -54,7 +52,7 @@ impl Context {
             mut args,
         } = self;
 
-        args.0.push((Arc::from(key.as_ref()), value.into()));
+        args.insert(key, value);
 
         Self { target, path, args }
     }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -74,12 +74,14 @@ type Expand = Rc<dyn Fn(&System, &Context) -> core::result::Result<Vec<Task>, Er
 pub enum Task {
     Atom {
         id: &'static str,
+        scoped: bool,
         context: Context,
         dry_run: DryRun,
         run: Run,
     },
     List {
         id: &'static str,
+        scoped: bool,
         context: Context,
         expand: Expand,
     },
@@ -94,6 +96,7 @@ impl Task {
         let handler_clone = handler.clone();
         Self::Atom {
             id,
+            scoped: handler.is_scoped(),
             context,
             dry_run: Rc::new(move |system: &System, context: &Context| {
                 let effect = handler_clone.call(system, context);
@@ -118,6 +121,7 @@ impl Task {
     {
         Self::List {
             id,
+            scoped: handler.is_scoped(),
             context,
             expand: Rc::new(move |system: &System, context: &Context| {
                 // List tasks cannot perform changes to the system
@@ -142,22 +146,32 @@ impl Task {
         }
     }
 
+    pub fn is_scoped(&self) -> bool {
+        match self {
+            Self::Atom { scoped, .. } => *scoped,
+            Self::List { scoped, .. } => *scoped,
+        }
+    }
+
     pub fn try_target<S: Serialize>(self, target: S) -> Result<Self> {
         let target = serde_json::to_value(target)?;
         let res = match self {
             Self::Atom {
                 id,
+                scoped,
                 context,
                 dry_run,
                 run,
             } => Self::Atom {
                 id,
+                scoped,
                 context: context.with_target(target),
                 dry_run,
                 run,
             },
             Self::List {
                 id,
+                scoped,
                 context,
                 expand,
                 ..
@@ -165,6 +179,7 @@ impl Task {
                 let Context { args, path, .. } = context;
                 Self::List {
                     id,
+                    scoped,
                     context: Context { target, args, path },
                     expand,
                 }
@@ -182,22 +197,26 @@ impl Task {
         match self {
             Self::Atom {
                 id,
+                scoped,
                 context,
                 dry_run,
                 run,
             } => Self::Atom {
                 id,
+                scoped,
                 context: context.with_arg(key, value),
                 dry_run,
                 run,
             },
             Self::List {
                 id,
+                scoped,
                 context,
                 expand,
                 ..
             } => Self::List {
                 id,
+                scoped,
                 context: context.with_arg(key, value),
                 expand,
             },
@@ -208,22 +227,26 @@ impl Task {
         match self {
             Self::Atom {
                 id,
+                scoped,
                 context,
                 dry_run,
                 run,
             } => Self::Atom {
                 id,
+                scoped,
                 context: context.with_path(path),
                 dry_run,
                 run,
             },
             Self::List {
                 id,
+                scoped: linear,
                 context,
                 expand,
                 ..
             } => Self::List {
                 id,
+                scoped: linear,
                 context: context.with_path(path),
                 expand,
             },

--- a/src/worker/planner.rs
+++ b/src/worker/planner.rs
@@ -264,7 +264,7 @@ mod tests {
 
     use super::*;
     use crate::extract::{Target, Update};
-    use crate::task::Handler;
+    use crate::task::*;
     use crate::worker::{none, update, Domain};
     use crate::{seq, Dag};
 

--- a/src/worker/planner.rs
+++ b/src/worker/planner.rs
@@ -264,7 +264,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::extract::{Path, System, Target, Update};
+    use crate::extract::{Args, System, Target, Update};
     use crate::task::*;
     use crate::worker::{none, update, Domain};
     use crate::{seq, Dag};
@@ -536,7 +536,7 @@ mod tests {
         fn pickup(
             mut loc: Update<Location>,
             System(sys): System<State>,
-            Path(block): Path<Block>,
+            Args(block): Args<Block>,
         ) -> Update<Location> {
             // if the block is clear and we are not holding any other blocks
             // we can grab the block
@@ -554,7 +554,7 @@ mod tests {
         fn unstack(
             mut loc: Update<Location>,
             System(sys): System<State>,
-            Path(block): Path<Block>,
+            Args(block): Args<Block>,
         ) -> Update<Location> {
             // if the block is clear and we are not holding any other blocks
             // we can grab the block


### PR DESCRIPTION
The `System` extractor allow jobs/tasks to get read access to the global system state.

While this is desirable sometimes, this also means that tasks created from functions using this extractor cannot be parallelized (they are strictly linear).

Change-type: minor