### PR TITLE
Make implementation multi-threading compatible

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,7 @@ pub enum Error {
     WorkflowInterrupted(#[from] super::worker::Interrupted),
 
     #[error(transparent)]
-    Other(#[from] Box<dyn std::error::Error>),
+    Other(#[from] Box<dyn std::error::Error + Send>),
 }
 
 pub trait IntoError {

--- a/src/task/boxed.rs
+++ b/src/task/boxed.rs
@@ -8,7 +8,7 @@ impl BoxedIntoTask {
     pub fn from_action<A, T, I>(action: A) -> Self
     where
         A: Handler<T, Patch, I>,
-        I: 'static,
+        I: Send + 'static,
     {
         Self(Box::new(MakeIntoTask {
             handler: action,
@@ -37,7 +37,7 @@ impl Clone for BoxedIntoTask {
     }
 }
 
-trait ErasedIntoTask: Send {
+trait ErasedIntoTask: Send + Sync {
     fn clone_box(&self) -> Box<dyn ErasedIntoTask>;
 
     fn into_task(self: Box<Self>, id: &'static str, context: Context) -> Task;
@@ -50,7 +50,7 @@ struct MakeIntoTask<H> {
 
 impl<H> ErasedIntoTask for MakeIntoTask<H>
 where
-    H: Send + Clone + 'static,
+    H: Send + Sync + Clone + 'static,
 {
     fn clone_box(&self) -> Box<dyn ErasedIntoTask> {
         Box::new(Self {

--- a/src/task/job.rs
+++ b/src/task/job.rs
@@ -53,7 +53,7 @@ impl Job {
     pub(crate) fn from_action<A, T, I>(action: A) -> Self
     where
         A: Handler<T, Patch, I>,
-        I: 'static,
+        I: Send + 'static,
     {
         let id = std::any::type_name::<A>();
 

--- a/src/worker/planner.rs
+++ b/src/worker/planner.rs
@@ -114,7 +114,11 @@ impl Planner {
                 let mut cur_state = cur_state.clone();
                 let mut cur_plan = cur_plan;
                 for mut t in tasks.into_iter() {
-                    // Merge the parent args into the child task args
+                    // A task cannot override the context set by the
+                    // parent task. For instance a method for `/a/b` cannot
+                    // have a sub-task for `/a/c`, it can however have a task
+                    // for `/a/b` or `/a/b/c`.
+                    // TODO: should we error if that happens or raise a warning
                     for (k, v) in context.args.iter() {
                         t = t.with_arg(k, v)
                     }

--- a/src/worker/workflow.rs
+++ b/src/worker/workflow.rs
@@ -96,7 +96,7 @@ impl<T: IntoTask + Clone> Dag<T> {
         // TODO: implement parallel execution of the DAG
         for node in self.iter() {
             let value = {
-                if let Node::Item { value, .. } = &*node.borrow() {
+                if let Node::Item { value, .. } = &*node.read().unwrap() {
                     // This clone is necessary for now because of the iterator, but a future version
                     // of execute will just consume the DAG, avoiding the need
                     // for cloning


### PR DESCRIPTION
Refactor the codebase to ensure types are Send. This also removes the requirement for a LocalSet when calling `seek_target`

Change-type: minor