### PR TITLE
Remove Result type alias

### DIFF
--- a/src/extract/view.rs
+++ b/src/extract/view.rs
@@ -7,9 +7,7 @@ use std::ops::{Deref, DerefMut};
 
 use crate::path::Path;
 use crate::system::{FromSystem, System};
-use crate::task::{
-    Context, Effect, Error, InputError, IntoEffect, IntoResult, Result, UnexpectedError,
-};
+use crate::task::{Context, Effect, Error, InputError, IntoEffect, IntoResult, UnexpectedError};
 
 /// Extracts a pointer to a sub-element of the global state indicated
 /// by the path.
@@ -61,7 +59,7 @@ impl<T> Pointer<T> {
 impl<T: DeserializeOwned> FromSystem for Pointer<T> {
     type Error = InputError;
 
-    fn from_system(system: &System, context: &Context) -> core::result::Result<Self, Self::Error> {
+    fn from_system(system: &System, context: &Context) -> Result<Self, Self::Error> {
         let json_ptr = context.path.as_ref();
         let root = system.root();
 
@@ -113,7 +111,7 @@ impl<T> DerefMut for Pointer<T> {
 }
 
 impl<T: Serialize> IntoResult<Patch> for Pointer<T> {
-    fn into_result(self, system: &System) -> Result<Patch> {
+    fn into_result(self, system: &System) -> Result<Patch, Error> {
         // Get the root value
         let mut after = system.clone();
         let root = after.root_mut();
@@ -163,7 +161,7 @@ impl<T> View<T> {
 impl<T: DeserializeOwned> FromSystem for View<T> {
     type Error = InputError;
 
-    fn from_system(system: &System, context: &Context) -> core::result::Result<Self, Self::Error> {
+    fn from_system(system: &System, context: &Context) -> Result<Self, Self::Error> {
         let pointer = Pointer::<T>::from_system(system, context)?;
 
         if pointer.state.is_none() {
@@ -191,7 +189,7 @@ impl<T> DerefMut for View<T> {
 }
 
 impl<T: Serialize> IntoResult<Patch> for View<T> {
-    fn into_result(self, system: &System) -> Result<Patch> {
+    fn into_result(self, system: &System) -> Result<Patch, Error> {
         self.0.into_result(system)
     }
 }

--- a/src/task/into_result.rs
+++ b/src/task/into_result.rs
@@ -6,12 +6,8 @@ use super::effect::{Effect, IntoEffect};
 use super::errors::{Error, RuntimeError};
 use crate::system::System;
 
-/// The task outcome is a type alias
-/// of Result
-pub type Result<O> = core::result::Result<O, Error>;
-
 pub trait IntoResult<O> {
-    fn into_result(self, system: &System) -> Result<O>;
+    fn into_result(self, system: &System) -> Result<O, Error>;
 }
 
 impl<T, O> IntoResult<O> for Option<T>
@@ -19,7 +15,7 @@ where
     O: Default,
     T: IntoResult<O>,
 {
-    fn into_result(self, system: &System) -> Result<O> {
+    fn into_result(self, system: &System) -> Result<O, Error> {
         self.map(|value| value.into_result(system))
             .ok_or_else(|| Error::ConditionFailed)?
     }


### PR DESCRIPTION
The benefits of the alias do not outweight the drawbacks of having to use core::result::Result for std results

Change-type: patch