### PR TITLE
Enable tracing in worker and add `logging` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,18 +4,33 @@ version = "0.7.1"
 edition = "2021"
 description = "An automated job orchestration library to build and execute dynamic workflows"
 
+[features]
+
+default = []
+logging = ["tracing-subscriber", "log"]
+
 [dependencies]
 anyhow = "1.0.97"
-json-patch = "3"
-jsonptr = "0.6.0"
-log = "0.4.25"
+json-patch = "4"
+jsonptr = "0.7.1"
 matchit = "0.8.4"
 serde = { version = "1.0.197" }
 serde_json = "1.0.120"
 thiserror = "2"
 tokio = { version = "1.43.0", features = ["rt", "time"] }
+tracing = "0.1.41"
+
+# only required by the `logging` feature
+log = { version = "0.4.25", optional = true }
+tracing-subscriber = { version = "0.3.19", default-features = false, optional = true, features = [
+  "registry",
+] }
 
 [dev-dependencies]
+tracing-subscriber = { version = "0.3.19", default-features = false, features = [
+  "registry",
+] }
 dedent = "0.1.1"
-env_logger = "0.11.6"
+env_logger = "0.11.8"
+log = "0.4.25"
 tokio = { version = "1.36.0", features = ["rt", "macros", "time"] }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -15,7 +15,7 @@ pub struct SerializationError(#[from] serde_json::error::Error);
 #[error(transparent)]
 pub struct PatchError(#[from] json_patch::PatchError);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct System {
     state: Value,
 }

--- a/src/task/context.rs
+++ b/src/task/context.rs
@@ -21,7 +21,7 @@ impl Context {
 
     pub fn with_path(self, path: impl AsRef<str>) -> Self {
         let path = Path::new(
-            PointerBuf::parse(&path)
+            PointerBuf::parse(path.as_ref())
                 // this is a bug if it happens
                 .expect("invalid JSON Pointer path")
                 .as_ptr(),

--- a/src/worker/distance.rs
+++ b/src/worker/distance.rs
@@ -1,6 +1,7 @@
 use json_patch::{diff, Patch, PatchOperation, RemoveOperation, ReplaceOperation};
 use jsonptr::Pointer;
 use serde_json::Value;
+use std::fmt::{self, Display};
 use std::{
     cmp::Ordering,
     collections::{BTreeSet, LinkedList},
@@ -11,6 +12,18 @@ use crate::task::Operation as IntentOperation;
 #[derive(Debug)]
 pub struct Distance(BTreeSet<Operation>);
 
+impl Display for Distance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
+        for (i, op) in self.0.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", op.0)?;
+        }
+        write!(f, "]")
+    }
+}
 impl Distance {
     /// Calculate the distance between some state and target
     ///
@@ -147,6 +160,12 @@ impl Operation {
             PatchOperation::Remove(..) => op == &IntentOperation::Delete,
             _ => false,
         }
+    }
+}
+
+impl Display for Operation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/src/worker/logging.rs
+++ b/src/worker/logging.rs
@@ -1,0 +1,227 @@
+use json_patch::{diff, Patch};
+use log::{log, Level};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Once;
+use tracing::field::{Field, Visit};
+use tracing::span::Attributes;
+use tracing::{Event, Id, Subscriber};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::{LookupSpan, Scope};
+use tracing_subscriber::{layer::Context, Layer};
+
+static INIT: Once = Once::new();
+pub fn init() {
+    INIT.call_once(|| tracing_subscriber::registry().with(ToLogLayer).init());
+}
+
+pub struct ToLogLayer;
+
+impl<S> Layer<S> for ToLogLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut map = HashMap::new();
+            let mut visitor = FieldMapVisitor::from_map(&mut map);
+            attrs.record(&mut visitor);
+
+            // Store the initial fields in span extensions
+            span.extensions_mut().insert(map);
+
+            let meta = span.metadata();
+            let name = meta.name();
+            // Report opening events
+            match name {
+                "seek_target" => {
+                    log!(target: meta.target(), Level::Info, "applying target state");
+                }
+                "find_workflow" => {
+                    log!(target: meta.target(), Level::Info, "searching workflow");
+                    if !log::log_enabled!(Level::Debug) {
+                        return;
+                    }
+                    let ext = span.extensions();
+                    if let Some(fields) = ext.get::<HashMap<String, String>>() {
+                        if let (Some(Ok(ini)), Some(Ok(tgt))) = (
+                            fields
+                                .get("ini")
+                                .map(|s| serde_json::from_str::<Value>(s.as_str())),
+                            fields
+                                .get("tgt")
+                                .map(|s| serde_json::from_str::<Value>(s.as_str())),
+                        ) {
+                            let Patch(changes) = diff(&ini, &tgt);
+                            if !changes.is_empty() {
+                                log!(target: meta.target(), Level::Debug, "pending changes");
+                                for change in changes {
+                                    log!(target: meta.target(), Level::Debug, "- {}", change);
+                                }
+                            }
+                        }
+                    }
+                }
+                "run_task" => {
+                    let ext = span.extensions();
+                    if let Some(fields) = ext.get::<HashMap<String, String>>() {
+                        if let Some(task) = fields.get("task") {
+                            log!(target: meta.target(), Level::Info, "{}: running ...", task);
+                        }
+                    }
+                }
+                _ => {}
+            };
+        }
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(&id) {
+            let meta = span.metadata();
+            let ext = span.extensions();
+
+            let name = meta.name();
+            let fields = ext.get::<HashMap<String, String>>();
+            match name {
+                "seek_target" => {
+                    if let Some(map) = fields {
+                        if let Some(result) = map.get("return") {
+                            match result.as_str() {
+                                "success" => {
+                                    log!(target: meta.target(), Level::Info, "target state applied")
+                                }
+                                "failure" => {
+                                    log!(target: meta.target(), Level::Info, "failed to apply target state")
+                                }
+                                "interrupted" => {
+                                    log!(target: meta.target(), Level::Warn, "workflow interrupted by user request")
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                "find_workflow" => {
+                    if let Some(map) = fields {
+                        if let Some(result) = map.get("return") {
+                            if result.is_empty() {
+                                log!(target: meta.target(), Level::Info, "nothing else to do: target state reached");
+                            } else {
+                                log!(target: meta.target(), Level::Info, "searching workflow: success");
+                                if !log::log_enabled!(Level::Debug) {
+                                    return;
+                                }
+                                log!(target: meta.target(), Level::Debug, "will execute the following tasks:");
+                                for action in result.split("\n") {
+                                    log!(target: meta.target(), Level::Debug, "{}", action);
+                                }
+                            }
+                        }
+                        if let Some(error) = map.get("error") {
+                            log!(target: meta.target(), Level::Warn, "searching workflow: failed - {}", error)
+                        }
+                    }
+                }
+                "run_task" => {
+                    if let Some(map) = fields {
+                        match (map.get("task"), map.get("error")) {
+                            (Some(task), Some(error)) => {
+                                log!(target: meta.target(), Level::Warn, "{}: failed - {}", task, error)
+                            }
+                            (Some(task), None) => {
+                                log!(target: meta.target(), Level::Info, "{}: found", task)
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                "run_workflow" => {
+                    if let Some(map) = fields {
+                        if map.get("error").is_none() {
+                            log!(target: meta.target(), Level::Info, "plan executed successfully")
+                        }
+                    }
+                }
+                _ => {}
+            };
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if let Some(span) = ctx
+            .event_scope(event)
+            .into_iter()
+            .flat_map(Scope::from_root)
+            .last()
+        {
+            let meta = event.metadata();
+            let level = map_level(meta.level());
+            let mut exts = span.extensions_mut();
+
+            // Get the existing field map (from on_new_span)
+            if let Some(fields) = exts.get_mut::<HashMap<String, String>>() {
+                let mut visitor = FieldMapVisitor::from_map(fields);
+                event.record(&mut visitor);
+
+                if let Some(message) = fields.get("message") {
+                    if span.name() == "find_workflow" {
+                        log!(target: meta.target(), level, "searching workflow: {} ", message)
+                    }
+                }
+            }
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &tracing::span::Record<'_>, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut exts = span.extensions_mut();
+
+            // Get the existing field map (from on_new_span)
+            if let Some(fields) = exts.get_mut::<HashMap<String, String>>() {
+                let mut visitor = FieldMapVisitor::from_map(fields);
+                values.record(&mut visitor);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct FieldMapVisitor<'a> {
+    fields: Option<&'a mut HashMap<String, String>>,
+}
+
+impl<'a> FieldMapVisitor<'a> {
+    pub fn from_map(map: &'a mut HashMap<String, String>) -> Self {
+        Self { fields: Some(map) }
+    }
+}
+
+impl Visit for FieldMapVisitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if let Some(ref mut map) = self.fields {
+            map.insert(field.name().into(), format!("{:?}", value));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if let Some(ref mut map) = self.fields {
+            map.insert(field.name().into(), value.to_string());
+        }
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if let Some(ref mut map) = self.fields {
+            map.insert(field.name().into(), value.to_string());
+        }
+    }
+}
+
+fn map_level(level: &tracing::Level) -> Level {
+    match *level {
+        tracing::Level::TRACE => Level::Trace,
+        tracing::Level::DEBUG => Level::Debug,
+        tracing::Level::INFO => Level::Info,
+        tracing::Level::WARN => Level::Warn,
+        tracing::Level::ERROR => Level::Error,
+    }
+}

--- a/src/worker/workflow.rs
+++ b/src/worker/workflow.rs
@@ -4,6 +4,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::AtomicBool;
+use tracing::instrument;
 
 use super::RuntimeError;
 use crate::dag::{Dag, Node};
@@ -78,6 +79,7 @@ impl Display for WorkUnit {
 }
 
 impl<T: Into<Action> + Clone> Dag<T> {
+    #[instrument(name = "run_workflow", skip_all, err)]
     pub(crate) async fn execute(
         self,
         system: &mut System,

--- a/tests/library_test.rs
+++ b/tests/library_test.rs
@@ -10,6 +10,15 @@ use gustav::worker::Worker;
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct Counters(HashMap<String, i32>);
 
+fn init() {
+    #[cfg(feature = "logging")]
+    gustav::worker::init_logging();
+    env_logger::builder()
+        .format_target(false)
+        .try_init()
+        .unwrap_or(());
+}
+
 fn plus_one(mut counter: View<i32>, Target(tgt): Target<i32>) -> Effect<View<i32>> {
     if *counter < tgt {
         // Modify the counter if we are below target
@@ -30,6 +39,7 @@ fn plus_one(mut counter: View<i32>, Target(tgt): Target<i32>) -> Effect<View<i32
 // this is just a placeholder test to check that library modules
 // are accessible
 async fn test_worker() {
+    init();
     let worker = Worker::new()
         .job("/{counter}", update(plus_one))
         .initial_state(Counters(HashMap::from([


### PR DESCRIPTION
The `logging` feature exposes an `init_logging` function on worker that registers a tracing subscriber that emits `log` crate human readable records. The crate requires importing the `tracing_subscriber` and `log` crates.

Change-type: minor