### PR TITLE
Allow describing tasks

### DIFF
--- a/src/extract/target.rs
+++ b/src/extract/target.rs
@@ -3,14 +3,14 @@ use serde::de::DeserializeOwned;
 use std::ops::Deref;
 
 use crate::system::{FromSystem, System};
-use crate::task::{Context, InputError};
+use crate::task::{Context, FromContext, InputError};
 
 pub struct Target<T>(pub T);
 
-impl<T: DeserializeOwned> FromSystem for Target<T> {
+impl<T: DeserializeOwned> FromContext for Target<T> {
     type Error = InputError;
 
-    fn from_system(_: &System, context: &Context) -> Result<Self, Self::Error> {
+    fn from_context(context: &Context) -> Result<Self, Self::Error> {
         let value = &context.target;
 
         // This will fail if the value cannot be deserialized into the target type
@@ -22,6 +22,14 @@ impl<T: DeserializeOwned> FromSystem for Target<T> {
         })?;
 
         Ok(Target(target))
+    }
+}
+
+impl<T: DeserializeOwned> FromSystem for Target<T> {
+    type Error = InputError;
+
+    fn from_system(_: &System, context: &Context) -> Result<Self, Self::Error> {
+        Self::from_context(context)
     }
 }
 

--- a/src/task/context.rs
+++ b/src/task/context.rs
@@ -1,6 +1,7 @@
 use jsonptr::PointerBuf;
 use serde_json::Value;
 
+use super::errors::Error;
 use crate::path::{Path, PathArgs};
 
 #[derive(Clone, Default, Debug)]
@@ -34,4 +35,10 @@ impl Context {
         args.insert(key, value);
         Self { args, ..self }
     }
+}
+
+pub trait FromContext: Sized {
+    type Error: Into<Error> + 'static;
+
+    fn from_context(context: &Context) -> Result<Self, Self::Error>;
 }

--- a/src/task/description.rs
+++ b/src/task/description.rs
@@ -1,0 +1,42 @@
+use super::{Context, Error, FromContext};
+
+pub trait Description<T>: Clone + Sync + Send + 'static {
+    fn call(&self, context: &Context) -> Result<String, Error>;
+}
+
+macro_rules! impl_description {
+    (
+        $first:ident, $($ty:ident),*
+    ) => {
+        #[allow(non_snake_case, unused)]
+        impl<F, Res, $($ty,)*> Description<($($ty,)*)> for F
+        where
+            F: Fn($($ty,)*) -> Res + Clone + Send + Sync +'static,
+            Res: Into<String>,
+            $($ty: FromContext,)*
+        {
+            fn call(&self, context: &Context) -> Result<String, Error> {
+                $(
+                    let $ty = match $ty::from_context(context) {
+                        Ok(value) => value,
+                        Err(failure) => {
+                            return Err(failure.into())
+                        }
+                    };
+                )*
+
+                Ok((self)($($ty,)*).into())
+            }
+
+        }
+    };
+}
+
+impl_description!(T1,);
+impl_description!(T1, T2);
+impl_description!(T1, T2, T3);
+impl_description!(T1, T2, T3, T4);
+impl_description!(T1, T2, T3, T4, T5);
+impl_description!(T1, T2, T3, T4, T5, T6);
+impl_description!(T1, T2, T3, T4, T5, T6, T7);
+impl_description!(T1, T2, T3, T4, T5, T6, T7, T8);

--- a/src/task/handler.rs
+++ b/src/task/handler.rs
@@ -1,9 +1,8 @@
 use json_patch::Patch;
 use serde::Serialize;
 
-use super::{Context, Effect, IntoEffect, Task};
+use super::{Context, Effect, Error, IntoEffect, Task};
 use crate::system::{FromSystem, System};
-use crate::task::Error;
 
 pub trait Handler<T, O, I = O>: Clone + Sync + Send + 'static {
     fn call(&self, system: &System, context: &Context) -> Effect<O, Error, I>;

--- a/src/task/job.rs
+++ b/src/task/job.rs
@@ -1,4 +1,5 @@
 use super::context::Context;
+use super::description::Description;
 use super::handler::Handler;
 use super::Task;
 use std::cmp::Ordering;
@@ -65,6 +66,22 @@ impl Job {
         Job {
             operation,
             task: job,
+            priority,
+        }
+    }
+
+    pub fn with_description<D, T>(self, description: D) -> Self
+    where
+        D: Description<T>,
+    {
+        let Job {
+            operation,
+            task: job,
+            priority,
+        } = self;
+        Job {
+            operation,
+            task: job.with_description(description),
             priority,
         }
     }

--- a/tests/library_test.rs
+++ b/tests/library_test.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::sleep;
 
-use gustav::extract::{Target, View};
+use gustav::extract::{Args, Target, View};
 use gustav::task::*;
 use gustav::worker::Worker;
 
@@ -41,23 +41,24 @@ fn plus_one(mut counter: View<i32>, Target(tgt): Target<i32>) -> Effect<View<i32
 async fn test_worker() {
     init();
     let worker = Worker::new()
-        .job("/{counter}", update(plus_one))
+        .job(
+            "/{counter}",
+            update(plus_one)
+                .with_description(|Args(counter): Args<String>| format!("{counter} + 1")),
+        )
         .initial_state(Counters(HashMap::from([
-            ("one".to_string(), 0),
-            ("two".to_string(), 0),
+            ("a".to_string(), 0),
+            ("b".to_string(), 0),
         ])))
         .seek_target(Counters(HashMap::from([
-            ("one".to_string(), 2),
-            ("two".to_string(), 0),
+            ("a".to_string(), 2),
+            ("b".to_string(), 0),
         ])));
 
     let worker = worker.wait(None).await.unwrap();
     let state = worker.state();
     assert_eq!(
         state,
-        Counters(HashMap::from([
-            ("one".to_string(), 2),
-            ("two".to_string(), 0),
-        ]))
+        Counters(HashMap::from([("a".to_string(), 2), ("b".to_string(), 0),]))
     );
 }


### PR DESCRIPTION
The task description is an optional function that can be passed when constructing the domain/worker that will be use in logging to identify the task based on the context

Change-type: minor