### PR TITLE
Add support for executing parallel workflows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ log = { version = "0.4.25", optional = true }
 tracing-subscriber = { version = "0.3.19", default-features = false, optional = true, features = [
   "registry",
 ] }
+futures = "0.3.31"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.19", default-features = false, features = [

--- a/src/ack_channel.rs
+++ b/src/ack_channel.rs
@@ -27,9 +27,16 @@ impl<T> Drop for WithAck<T> {
 }
 
 /// An acknowledged sender
-#[derive(Clone)]
 pub struct Sender<T> {
     inner: mpsc::Sender<WithAck<T>>,
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<T> Sender<T> {

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 use tracing::instrument;
 
 use crate::ack_channel::Sender;
-use crate::dag::{Dag, ExecutionStatus, Task};
+use crate::dag::{AggregateError, Dag, ExecutionStatus, Task};
 use crate::system::System;
 use crate::task::{Action, Error as TaskError};
 
@@ -139,12 +139,12 @@ impl Workflow {
     }
 
     #[instrument(name = "run_workflow", skip_all, err)]
-    pub async fn execute(
+    pub(crate) async fn execute(
         self,
         system: &Arc<RwLock<System>>,
         channel: Sender<Patch>,
         sigint: &Arc<AtomicBool>,
-    ) -> Result<WorkflowStatus, TaskError> {
+    ) -> Result<WorkflowStatus, AggregateError<TaskError>> {
         self.dag
             .execute(system, channel, sigint)
             .await


### PR DESCRIPTION
Running DAGs now creates separate futures for graph branches that are joined later. This means that workflows with IO operations will run in parallel. Note that branches do not spawn new tokio tasks, so long running synchronous tasks (rather than I/O operations) may still result in inefficient execution of workflows.

Change-type: minor