### PR TITLE
Refactor error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0.197" }
 serde_json = "1.0.120"
 thiserror = "2"
 tokio = { version = "1.43.0", default-features = false, features = [
+  "rt",
   "sync",
   "macros",
 ] }

--- a/examples/composer/src/lib.rs
+++ b/examples/composer/src/lib.rs
@@ -776,7 +776,7 @@ mod tests {
 
         // Seeking the target must succeed
         let worker = worker.seek_target(target.clone()).await.unwrap();
-        assert_eq!(worker.status(), &SeekStatus::TargetStateReached);
+        assert_eq!(worker.status(), &SeekStatus::TargetReached);
 
         // The alpine image must exist now
         let docker = Docker::connect_with_defaults().unwrap();
@@ -934,7 +934,7 @@ mod tests {
 
         // Seeking the target must succeed
         let worker = worker.seek_target(target).await.unwrap();
-        assert_eq!(worker.status(), &SeekStatus::TargetStateReached);
+        assert_eq!(worker.status(), &SeekStatus::TargetReached);
 
         // The alpine image must exist now
         let docker = Docker::connect_with_defaults().unwrap();
@@ -973,7 +973,7 @@ mod tests {
 
         // Seeking the target must succeed
         let worker = worker.seek_target(target).await.unwrap();
-        assert_eq!(worker.status(), &SeekStatus::TargetStateReached);
+        assert_eq!(worker.status(), &SeekStatus::TargetReached);
 
         // The container ids should match
         let container = docker
@@ -1000,7 +1000,7 @@ mod tests {
 
         // Seeking the target must succeed
         let worker = worker.seek_target(target).await.unwrap();
-        assert_eq!(worker.status(), &SeekStatus::TargetStateReached);
+        assert_eq!(worker.status(), &SeekStatus::TargetReached);
 
         // The container ids should match
         let container = docker
@@ -1021,7 +1021,7 @@ mod tests {
 
         // Seeking the target must succeed
         let worker = worker.seek_target(target).await.unwrap();
-        assert_eq!(worker.status(), &SeekStatus::TargetStateReached);
+        assert_eq!(worker.status(), &SeekStatus::TargetReached);
 
         // The container should no longer exist
         let container = docker

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,55 @@
+use std::ops::Deref;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("argument extraction failed: {0:?}")]
+/// Arguments to a task could not be extracted.
+/// This is likely to be an error with the task definition.
+pub struct ExtractionError(#[from] anyhow::Error);
+
+#[derive(Debug, Error)]
+#[error("serialization error: {0:?}")]
+/// An error happened while serializing or deserializing an input type
+pub struct SerializationError(#[from] serde_json::Error);
+
+#[derive(Debug, Error)]
+#[error("internal error, this may be a bug: {0:?}")]
+/// Some unexpected error happened during the worker operation, either
+/// planning or runtime. These errors should not happen, unless
+/// there is a bug in the implementation.
+pub struct InternalError(#[from] anyhow::Error);
+
+#[derive(Debug, Error)]
+#[error("method expansion failed: {0:?}")]
+/// An error happened while trying to expand the method
+/// task into its sub-tasks. This is likely an issue with the
+/// method definition
+pub struct MethodError(Box<dyn std::error::Error + Send + Sync>);
+
+impl MethodError {
+    pub fn new<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
+        Self(Box::new(err))
+    }
+}
+
+#[derive(Debug, Error)]
+#[error(transparent)]
+/// An error happened while executing the task within the workflow.
+/// These errors only happen at runtime, never at the planning stage
+/// of the worker.
+pub struct IOError(Box<dyn std::error::Error + Send + Sync>);
+
+impl IOError {
+    pub fn new<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
+        Self(Box::new(err))
+    }
+}
+
+impl Deref for IOError {
+    type Target = Box<dyn std::error::Error + Send + Sync>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/extract/args/mod.rs
+++ b/src/extract/args/mod.rs
@@ -2,8 +2,9 @@ use anyhow::Context as AnyhowCtx;
 use serde::de::DeserializeOwned;
 use std::ops::Deref;
 
+use crate::errors::ExtractionError;
 use crate::system::{FromSystem, System};
-use crate::task::{Context, FromContext, InputError};
+use crate::task::{Context, FromContext};
 
 mod de;
 mod error;
@@ -12,7 +13,7 @@ mod error;
 pub struct Args<T>(pub T);
 
 impl<T: DeserializeOwned + Send> FromContext for Args<T> {
-    type Error = InputError;
+    type Error = ExtractionError;
 
     fn from_context(context: &Context) -> Result<Self, Self::Error> {
         let args = &context.args;
@@ -28,7 +29,7 @@ impl<T: DeserializeOwned + Send> FromContext for Args<T> {
 }
 
 impl<T: DeserializeOwned + Send> FromSystem for Args<T> {
-    type Error = InputError;
+    type Error = ExtractionError;
 
     fn from_system(_: &System, context: &Context) -> Result<Self, Self::Error> {
         Self::from_context(context)

--- a/src/extract/path.rs
+++ b/src/extract/path.rs
@@ -1,12 +1,13 @@
 use std::fmt::{Display, Formatter};
 
+use crate::errors::ExtractionError;
 use crate::system::{FromSystem, System};
-use crate::task::{Context, FromContext, InputError};
+use crate::task::{Context, FromContext};
 
 pub struct Path(pub String);
 
 impl FromContext for Path {
-    type Error = InputError;
+    type Error = ExtractionError;
 
     fn from_context(context: &Context) -> Result<Self, Self::Error> {
         let path = context.path.to_str();
@@ -22,7 +23,7 @@ impl Display for Path {
 }
 
 impl FromSystem for Path {
-    type Error = InputError;
+    type Error = ExtractionError;
 
     fn from_system(_: &System, context: &Context) -> Result<Self, Self::Error> {
         Self::from_context(context)

--- a/src/extract/res.rs
+++ b/src/extract/res.rs
@@ -2,13 +2,14 @@ use anyhow::Context as AnyhowCxt;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use crate::errors::ExtractionError;
 use crate::system::{FromSystem, System};
-use crate::task::{Context, InputError};
+use crate::task::Context;
 
 pub struct Res<R>(Arc<R>);
 
 impl<R: Send + Sync + 'static> FromSystem for Res<R> {
-    type Error = InputError;
+    type Error = ExtractionError;
 
     fn from_system(system: &System, _: &Context) -> Result<Self, Self::Error> {
         let arc = system
@@ -19,7 +20,7 @@ impl<R: Send + Sync + 'static> FromSystem for Res<R> {
                     std::any::type_name::<R>()
                 )
             })
-            .map_err(InputError::from)?;
+            .map_err(ExtractionError::from)?;
         Ok(Res(arc))
     }
 }

--- a/src/extract/system.rs
+++ b/src/extract/system.rs
@@ -1,15 +1,16 @@
 use anyhow::Context as AnyhowCtx;
 use serde::de::DeserializeOwned;
 
+use crate::errors::ExtractionError;
 use crate::system::{FromSystem, System as SystemState};
-use crate::task::{Context, InputError};
+use crate::task::Context;
 
 /// Extracts the root of the system state
 #[derive(Debug, Clone)]
 pub struct System<S>(pub S);
 
 impl<S: DeserializeOwned> FromSystem for System<S> {
-    type Error = InputError;
+    type Error = ExtractionError;
 
     fn from_system(system: &SystemState, _: &Context) -> Result<Self, Self::Error> {
         // This will fail if the value cannot be deserialized into the target type

--- a/src/extract/target.rs
+++ b/src/extract/target.rs
@@ -2,13 +2,14 @@ use anyhow::Context as AnyhowCxt;
 use serde::de::DeserializeOwned;
 use std::ops::Deref;
 
+use crate::errors::ExtractionError;
 use crate::system::{FromSystem, System};
-use crate::task::{Context, FromContext, InputError};
+use crate::task::{Context, FromContext};
 
 pub struct Target<T>(pub T);
 
 impl<T: DeserializeOwned> FromContext for Target<T> {
-    type Error = InputError;
+    type Error = ExtractionError;
 
     fn from_context(context: &Context) -> Result<Self, Self::Error> {
         let value = &context.target;
@@ -26,7 +27,7 @@ impl<T: DeserializeOwned> FromContext for Target<T> {
 }
 
 impl<T: DeserializeOwned> FromSystem for Target<T> {
-    type Error = InputError;
+    type Error = ExtractionError;
 
     fn from_system(_: &System, context: &Context) -> Result<Self, Self::Error> {
         Self::from_context(context)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod path;
 mod planner;
 mod system;
 
+pub mod errors;
 pub mod extract;
 pub mod task;
 pub mod worker;

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use thiserror::Error;
 use tracing::{debug, debug_span, error, field, instrument, warn, Level, Span};
 
+use crate::errors::{InternalError, MethodError, SerializationError};
 use crate::path::Path;
 use crate::system::System;
 use crate::task::{self, Context, Operation, Task};
@@ -23,42 +24,38 @@ pub use domain::*;
 pub struct Planner(Domain);
 
 #[derive(Debug, Error)]
-enum SearchError {
+enum SearchFailed {
     #[error("method error: {0}")]
-    CannotExpand(#[source] PathSearchError),
+    BadMethod(#[from] PathSearchError),
 
-    #[error("task error: {0}")]
-    Task(#[from] task::Error),
+    #[error("task error: {0:?}")]
+    BadTask(#[from] task::Error),
 
-    #[error("task condition failed")]
-    ConditionFailed,
+    #[error("task empty")]
+    EmptyTask,
 
     #[error("loop detected")]
     LoopDetected,
 
     // this is probably a bug if this error
     // happens
-    #[error("unexpected error: {0}")]
-    Unexpected(#[from] anyhow::Error),
+    #[error("internal error: {0:?}")]
+    Internal(#[from] anyhow::Error),
 }
-
-#[derive(Debug, Error)]
-#[error(transparent)]
-pub struct TaskError(#[from] anyhow::Error);
 
 #[derive(Debug, Error)]
 pub(crate) enum Error {
     #[error(transparent)]
-    Task(#[from] TaskError),
+    Serialization(#[from] SerializationError),
+
+    #[error(transparent)]
+    Task(#[from] task::Error),
 
     #[error("workflow not found")]
     NotFound,
 
-    #[error("max search depth reached")]
-    MaxDepthReached,
-
     #[error(transparent)]
-    Unexpected(#[from] anyhow::Error),
+    Internal(#[from] InternalError),
 }
 
 impl Planner {
@@ -77,23 +74,23 @@ impl Planner {
         cur_state: &System,
         cur_plan: Workflow,
         stack_len: u32,
-    ) -> Result<Workflow, SearchError> {
+    ) -> Result<Workflow, SearchFailed> {
         match task {
             Task::Action(action) => {
                 let work_id = WorkUnit::new_id(&action, cur_state.root());
 
                 // Detect loops in the plan
                 if cur_plan.as_dag().some(|a| a.id == work_id) {
-                    return Err(SearchError::LoopDetected)?;
+                    return Err(SearchFailed::LoopDetected)?;
                 }
 
                 // Test the task
-                let Patch(changes) = action.dry_run(cur_state).map_err(SearchError::Task)?;
+                let Patch(changes) = action.dry_run(cur_state).map_err(SearchFailed::BadTask)?;
 
                 // if we are at the top of the stack and no changes are introduced
                 // then assume the condition has failed
                 if stack_len == 0 && changes.is_empty() {
-                    return Err(SearchError::ConditionFailed);
+                    return Err(SearchFailed::EmptyTask);
                 }
 
                 // Otherwise add the task to the plan
@@ -106,7 +103,7 @@ impl Planner {
                 Ok(Workflow { dag, pending })
             }
             Task::Method(method) => {
-                let tasks = method.expand(cur_state).map_err(SearchError::Task)?;
+                let tasks = method.expand(cur_state).map_err(SearchFailed::BadTask)?;
 
                 let mut cur_state = cur_state.clone();
                 let mut cur_plan = cur_plan;
@@ -124,11 +121,10 @@ impl Planner {
                     let Context { args, .. } = t.context_mut();
                     let path = self
                         .0
-                        .find_path_for_job(task_id.as_str(), args)
                         // The user may have not have put the child task in the
                         // domain, or failed to account for all args in the path
                         // in which case we need to return an error
-                        .map_err(SearchError::CannotExpand)?;
+                        .find_path_for_job(task_id.as_str(), args)?;
 
                     // Now that we have the proper path, look
                     // up the job at the domain to get any additional metadata
@@ -148,7 +144,7 @@ impl Planner {
                     cur_state
                         .patch(Patch(pending.clone()))
                         // not sure how this can happen, perhaps a bad method definition?
-                        .context(format!("failed to apply patch {pending:?}"))?;
+                        .with_context(|| format!("failed to apply patch {pending:?}"))?;
 
                     // But accumulate the changes separately to avoid
                     // applying them twice
@@ -162,7 +158,7 @@ impl Planner {
                 // if we are at the top of the stack and no changes are introduced
                 // then assume the condition has failed
                 if stack_len == 0 && changes.is_empty() {
-                    return Err(SearchError::ConditionFailed)?;
+                    return Err(SearchFailed::EmptyTask)?;
                 }
 
                 let mut cur_plan = cur_plan;
@@ -188,9 +184,10 @@ impl Planner {
         while let Some((cur_state, cur_plan, depth)) = stack.pop() {
             // we need to limit the search depth to avoid following
             // a buggy task forever
-            // TODO: make this configurable
             if depth >= 256 {
-                return Err(Error::MaxDepthReached)?;
+                // TODO: make this configurable
+                warn!(parent: &find_worflow_span, "reached max search depth (256) while looking for a plan");
+                return Err(Error::NotFound)?;
             }
 
             // There may be fields in internal state that we don't want
@@ -200,8 +197,7 @@ impl Planner {
             let cur = cur_state
                 .state::<T>()
                 .and_then(System::try_from)
-                // TODO: return seriaization error
-                .with_context(|| "failed to serialize state")?;
+                .map_err(SerializationError::from)?;
 
             let distance = Distance::new(&cur, tgt);
 
@@ -261,7 +257,8 @@ impl Planner {
                                     // Update the state and the workflow
                                     new_sys
                                         .patch(Patch(pending))
-                                        .with_context(|| "failed to apply system patch")?;
+                                        .with_context(|| "failed to apply patch")
+                                        .map_err(InternalError::from)?;
                                     let new_plan = Workflow {
                                         dag,
                                         pending: vec![],
@@ -272,16 +269,24 @@ impl Planner {
                                     stack.push((new_sys, new_plan, depth + 1));
                                 }
                                 // Ignore harmless errors
-                                Err(SearchError::Task(task::Error::ConditionFailed)) => {}
-                                Err(SearchError::LoopDetected) => {}
-                                Err(SearchError::ConditionFailed) => {}
-                                // this is probably a bug so we terminate the search
-                                Err(SearchError::Unexpected(err)) => {
-                                    return Err(Error::Unexpected(err))
-                                }
-                                Err(err) => {
+                                Err(SearchFailed::LoopDetected) => {}
+
+                                Err(SearchFailed::EmptyTask) => {}
+                                Err(SearchFailed::BadTask(task::Error::ConditionFailed)) => {}
+                                // Transform errors to the corresponding result
+                                Err(SearchFailed::BadMethod(err)) => {
+                                    let err = MethodError::new(err);
                                     if cfg!(debug_assertions) {
-                                        return Err(TaskError(anyhow!(err)))?;
+                                        return Err(task::Error::from(err))?;
+                                    }
+                                    warn!(parent: &find_worflow_span, "task {} failed during planning: {} ... ignoring", task_id, err);
+                                }
+                                Err(SearchFailed::Internal(err)) => {
+                                    return Err(InternalError::from(err))?
+                                }
+                                Err(SearchFailed::BadTask(err)) => {
+                                    if cfg!(debug_assertions) {
+                                        return Err(err)?;
                                     }
                                     warn!(parent: &find_worflow_span, "task {} failed during planning: {} ... ignoring", task_id, err);
                                 }
@@ -614,7 +619,7 @@ mod tests {
             mut loc: View<Location>,
             System(sys): System<State>,
             Args(block): Args<Block>,
-        ) -> View<Location> {
+        ) -> Option<View<Location>> {
             // if the block is clear and we are not holding any other blocks
             // we can grab the block
             if loc.is_block()
@@ -622,9 +627,10 @@ mod tests {
                 && !is_holding(&sys.blocks)
             {
                 *loc = Location::Hand;
+                return Some(loc);
             }
 
-            loc
+            None
         }
 
         // There is really not that much of a difference between putdown and stack
@@ -661,7 +667,7 @@ mod tests {
             if is_clear(&sys.blocks, &Location::Blk(block)) {
                 if *loc == Location::Table {
                     return Some(pickup.into_task());
-                } else if *loc != Location::Hand {
+                } else {
                     return Some(unstack.into_task());
                 }
             }

--- a/src/worker/logging.rs
+++ b/src/worker/logging.rs
@@ -91,9 +91,6 @@ where
                                 "success" => {
                                     log!(target: meta.target(), Level::Info, "target state applied")
                                 }
-                                "failure" => {
-                                    log!(target: meta.target(), Level::Info, "failed to apply target state")
-                                }
                                 "interrupted" => {
                                     log!(target: meta.target(), Level::Warn, "target state apply interrupted by user request")
                                 }

--- a/src/worker/testing.rs
+++ b/src/worker/testing.rs
@@ -150,11 +150,11 @@ impl<O, I> Worker<O, Ready, I> {
     /// let worker = Worker::new().job("", update(plus_one)).initial_state::<i32>(0).unwrap();
     ///
     /// // Run task emulating a target of 2 and initial state of 0
-    /// assert_eq!(worker.run_task(plus_one.with_target(2)).await, Ok(1));
+    /// assert_eq!(worker.run_task(plus_one.with_target(2)).await.unwrap(), 1);
     ///
     /// // Run task emulating a target of 2 and initial state of 2 (no changes)
     /// let worker = Worker::new().job("", update(plus_one)).initial_state::<i32>(2).unwrap();
-    /// assert_eq!(worker.run_task(plus_one.with_target(2)).await, Ok(2));
+    /// assert_eq!(worker.run_task(plus_one.with_target(2)).await.unwrap(), 2);
     /// # })
     /// ```
     pub async fn run_task(&self, mut task: Task) -> Result<O, task::Error>

--- a/src/workflow/aggregate_error.rs
+++ b/src/workflow/aggregate_error.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::{self, Display},
-    ops::Deref,
+    ops::{Deref, DerefMut},
 };
 use thiserror::Error;
 
@@ -27,5 +27,11 @@ impl<E> Deref for AggregateError<E> {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl<E> DerefMut for AggregateError<E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -16,7 +16,7 @@ mod channel;
 mod dag;
 mod interrupt;
 
-pub use aggregate_error::*;
+pub(crate) use aggregate_error::*;
 pub(crate) use channel::*;
 pub use dag::*;
 pub(crate) use interrupt::*;


### PR DESCRIPTION
This change organizes error types to distinguish errors that can happen at different stages of the worker lifecycle. This should make it easier for users to identify what caused a `Worker::seek()` operation to fail or be aborted

Change-type: patch