### PR TITLE
Add support for parallel workflow generation

### DIFF
--- a/src/extract/target.rs
+++ b/src/extract/target.rs
@@ -6,6 +6,7 @@ use crate::errors::ExtractionError;
 use crate::system::{FromSystem, System};
 use crate::task::{Context, FromContext};
 
+#[derive(Debug)]
 pub struct Target<T>(pub T);
 
 impl<T: DeserializeOwned> FromContext for Target<T> {

--- a/src/path.rs
+++ b/src/path.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-#[derive(Clone, Default, PartialEq, Debug)]
+#[derive(Clone, Default, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub struct Path(PointerBuf);
 
 impl Path {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use tracing::warn;
 
 use crate::errors::SerializationError;
+use crate::path::Path;
 use crate::system::System;
 
 pub(crate) use context::*;
@@ -222,6 +223,13 @@ impl Task {
         match self {
             Self::Action(Action { id, .. }) => id,
             Self::Method(Method { id, .. }) => id,
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        match self {
+            Self::Action(Action { context, .. }) => &context.path,
+            Self::Method(Method { context, .. }) => &context.path,
         }
     }
 

--- a/src/worker/testing.rs
+++ b/src/worker/testing.rs
@@ -197,7 +197,7 @@ mod tests {
 
     use super::*;
     use crate::extract::{Target, View};
-    use crate::{seq, task::*, Dag};
+    use crate::{par, seq, task::*, Dag};
 
     fn plus_one(mut counter: View<i32>, tgt: Target<i32>) -> View<i32> {
         if *counter < *tgt {
@@ -294,11 +294,10 @@ mod tests {
             .unwrap();
 
         // We expect a linear DAG with three tasks
-        let expected: Dag<&str> = seq!(
+        let expected: Dag<&str> = par!(
             "gustav::worker::testing::tests::plus_one(/one)",
-            "gustav::worker::testing::tests::plus_one(/one)",
-            "gustav::worker::testing::tests::plus_one(/two)",
-        );
+            "gustav::worker::testing::tests::plus_one(/two)"
+        ) + seq!("gustav::worker::testing::tests::plus_one(/one)",);
 
         assert_eq!(workflow.to_string(), expected.to_string(),);
     }

--- a/src/workflow/dag.rs
+++ b/src/workflow/dag.rs
@@ -174,7 +174,6 @@ impl<T> Dag<T> {
     /// Link the current Dag to the Dag
     /// passed as argument
     pub fn concat(self, other: Dag<T>) -> Self {
-        debug_assert!(self.tail.is_some());
         if let Some(tail_node) = self.tail {
             match *tail_node.write().unwrap() {
                 Node::Item { ref mut next, .. } => {
@@ -186,6 +185,9 @@ impl<T> Dag<T> {
                 // The tail should never point to a fork
                 Node::Fork { .. } => unreachable!(),
             }
+        } else {
+            // this dag is empty
+            return other;
         }
 
         Dag {

--- a/src/workflow/dag.rs
+++ b/src/workflow/dag.rs
@@ -136,6 +136,14 @@ impl<T> Dag<T> {
         self.tail.is_none()
     }
 
+    pub fn is_forking(&self) -> bool {
+        if let Some(head) = &self.head {
+            matches!(*head.read().unwrap(), Node::Fork { .. })
+        } else {
+            false
+        }
+    }
+
     /// Link the current Dag to the Dag
     /// passed as argument
     pub fn concat(self, other: Dag<T>) -> Self {

--- a/src/workflow/dag.rs
+++ b/src/workflow/dag.rs
@@ -577,6 +577,16 @@ macro_rules! dag {
     };
 }
 
+#[macro_export]
+macro_rules! par {
+    // If the input is a list of values (strings, etc.), convert each to a single-element Dag
+    ($($value:expr),* $(,)?) => {
+        $crate::Dag::from_branches([
+            $($crate::Dag::from_sequence([$value])),*
+        ])
+    }
+}
+
 pub(crate) enum ExecutionStatus {
     Completed,
     Interrupted,

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -133,14 +133,6 @@ impl Workflow {
         &self.dag
     }
 
-    pub(crate) fn reverse(self) -> Self {
-        let Self { dag, pending } = self;
-        Self {
-            dag: dag.reverse(),
-            pending,
-        }
-    }
-
     pub fn is_empty(&self) -> bool {
         self.dag.is_empty()
     }


### PR DESCRIPTION
## Release Notes

This introduces a first version of parallel plan generation into the planner. This takes advantage of the scoped nature of tasks to select tasks for non-conflicting paths and run them as parallel branches in the generated workflow. This also does the same for methods, where a method returning tasks for non-conflicting paths is executed as parallel branches. 

The planning algorithm is still quite crude, future versions should use some cost optimization heuristic taking into account the depth of the workflow, number of changes introduced by the task, etc.