### PR TITLE
 Add method expansion control for concurrency with Sequence and Set wrappers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,7 +357,7 @@
 //! }
 //! ```
 //!
-//! ## Compound Jobs
+//! ## Methods
 //!
 //! Sometimes it may be desirable to re-use jobs in different contexts, or combine multiple jobs in
 //! order to guide the planner. This can be achieved by the use of compound jobs, called
@@ -409,6 +409,34 @@
 //! a reverse search for the paths corresponding to the tasks returned by the
 //! method. Failing to do this will result in an failure when planning.
 //! </div>
+//!
+//! ### Controlling method expansion
+//!
+//! Methods can control how their returned tasks are expanded for execution using wrapper types
+//! [`task::Sequence`] and [`task::Set`]
+//!
+//! ```rust
+//! use mahler::extract::{View, Target};
+//! use mahler::task::{Task, Sequence, Set, Handler};
+//!
+//! // Force sequential execution
+//! fn sequential_ops() -> Sequence {
+//!     vec![task_one.into_task(), task_two.into_task()].into()
+//! }
+//!
+//! // Allow concurrent execution regardless of task scoping
+//! fn independent_ops() -> Set {
+//!     vec![task_one.into_task(), task_two.into_task()].into()
+//! }
+//!
+//! // Use automatic detection based on task scoping (default)
+//! fn auto_ops() -> Vec<Task> {
+//!     vec![task_one.into_task(), task_two.into_task()]
+//! }
+//!
+//! fn task_one() {}
+//! fn task_two() {}
+//! ```
 //!
 //! # Error handling
 //!

--- a/src/task/handler.rs
+++ b/src/task/handler.rs
@@ -122,7 +122,11 @@ macro_rules! impl_action_handler {
     };
 }
 
-/// Trait for labeling Method outputs
+/// Trait for controlling method task expansion behavior
+///
+/// This trait allows method return types to specify how their tasks
+/// should be expanded for execution. The default behavior is to detect
+/// concurrency automatically based on task scoping.
 pub trait WithExpansion {
     fn expansion() -> Expansion {
         Expansion::default()

--- a/src/task/into_result.rs
+++ b/src/task/into_result.rs
@@ -72,7 +72,7 @@ impl<const N: usize> From<[Task; N]> for Effect<Vec<Task>, Error> {
     }
 }
 
-impl<const N: usize> WithExpansion for Vec<[Task; N]> {}
+impl<const N: usize> WithExpansion for [Task; N] {}
 
 // Allow methods to return a single task
 impl From<Task> for Effect<Vec<Task>, Error> {


### PR DESCRIPTION
- Add `Sequence` and `Set` wrapper types to control method task expansion behavior
- Implement `WithExpansion` trait for controlling expansion strategies
- Update method scoping evaluation to check sub-task scoping recursively
- Add comprehensive tests for all expansion control scenarios

This closes issues #32 and #33

## Release notes

Introduces two new types: `task::Sequence` and `task::Set`. These types allow to control how methods are expanded during planning.

- `Sequence` tells the planner that tasks provided by the method should be executed in sequence no matter their scoping or paths
- `Set`, tells the planner that two tasks can be executed concurrently independent of their scoping if they don't have conflicting paths.

Returning `Vec` or a slice, just defaults to automatic detection of concurrency from the task scoping and paths, same as before.

This PR also fixes how task scoping is evaluated for methods. The method scoping is inferred from the expanded task scoping rather than the use of `System` extractor in methods (see issue #32)

### Example

```rust
use mahler::extract::{View, Target};
use mahler::task::{Task, Sequence, Set, Handler};

// Force sequential execution
fn sequential_ops() -> Sequence {
    vec![task_one.into_task(), task_two.into_task()].into()
}

// Allow concurrent execution regardless of task scoping
fn independent_ops() -> Set {
    vec![task_one.into_task(), task_two.into_task()].into()
}

// Use automatic detection based on task scoping (default)
fn auto_ops() -> Vec<Task> {
    vec![task_one.into_task(), task_two.into_task()]
}

fn task_one() {}
fn task_two() {}
```

