### PR TITLE
Refactor conflict detection in planner

### DIFF
--- a/examples/composer/src/lib.rs
+++ b/examples/composer/src/lib.rs
@@ -305,7 +305,7 @@ fn remove_image(
     if project
         .services
         .values()
-        .any(|s| s.image == Some(image_name.clone()))
+        .any(|s| s.image.as_ref() == Some(&image_name))
     {
         return img_ptr.into();
     }


### PR DESCRIPTION
Replace the change-based conflict detection with simpler domain-based approach. Tasks now expose their operational domain directly rather than requiring is_scoped checks.

This fixes a potential bug in change-only comparison. Changes at planning are not fully representative of what happens at runtime. Based on changes only, the planner could configure tasks to run concurrently that step over each other at runtime. The task indicating its domain of action and using that for conflict detection is the right way to avoid conflicts.

Change-type: patch