### PR TITLE
Remove backtracking from planner search

### DIFF
--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
+    fmt::Display,
     ops::Deref,
     sync::Arc,
 };
@@ -57,6 +58,12 @@ impl std::fmt::Debug for System {
             .field("state", &self.state)
             .field("resources", &"Resources { ... }")
             .finish()
+    }
+}
+
+impl Display for System {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.state.fmt(f)
     }
 }
 


### PR DESCRIPTION
## Release notes

Replaces depth-first search planning algorithm with greedy approach to avoid combinatorial explosion. This now means that the planner will terminate quickly if there is no plan can be found by following the best candidate at each search level. 

This has the added benefit of making the task domain easier to debug. The tracing logs will now show the cumulative workflow at each search iteration and the remaining changes to be addressed. This means that, if the planner gives up, it is easy to see what was the longest plan found before no more candidates could be found.